### PR TITLE
Fix activation not writing to pipe

### DIFF
--- a/src/toasteventhandler.cpp
+++ b/src/toasteventhandler.cpp
@@ -79,6 +79,13 @@ IFACEMETHODIMP ToastEventHandler::Invoke(_In_ IToastNotification * /*sender*/,
             std::wcout << dataMap.at(L"button") << std::endl;
             m_userAction = SnoreToastActions::Actions::ButtonClicked;
         }
+        if (!m_toast.pipeName().empty()) {
+            if (m_userAction == SnoreToastActions::Actions::ButtonClicked) {
+                Utils::writePipe(m_toast.pipeName(), m_toast.formatAction(m_userAction, { { L"button", dataMap.at(L"button") } }));
+            } else {
+                Utils::writePipe(m_toast.pipeName(), m_toast.formatAction(m_userAction));
+            }
+        }
     }
     SetEvent(m_event);
     return S_OK;


### PR DESCRIPTION
I noticed this while using `node-notifier`, which uses the pipe functionality to receive the response. This worked for dismissing and timeout, and for activation via the background callback. However, in the case where the app shortcut isn't installed via snoretoast, there is no background callback registered so we need to rely on the normal activation event handler, which never wrote to the pipe.

I've taken a shot at fixing this by writing the action to the pipe, including the button for click events. I didn't test text entry, it may need another extra value too.